### PR TITLE
Add splash page and modify auth worflow

### DIFF
--- a/lib/blocs/user/user_bloc.dart
+++ b/lib/blocs/user/user_bloc.dart
@@ -24,19 +24,26 @@ class UserBloc extends HydratedBloc<UserEvent, UserState> {
 
   UserBloc() : super(const UserLoggedOut()) {
     on<CheckUser>((event, emit) async {
-      await Future.delayed(const Duration(milliseconds: 800));
       if (state is UserLoggedIn) {
         add(GetUserData(sessionId));
       } else {
+        // really quick transition to login page looks wierd
+        await Future.delayed(const Duration(milliseconds: 400));
         // go to login page
-        emit(const UserLoggedOut(showMsg: false));
+        emit(const UserLoggedOut(fromSplash: true));
       }
     });
 
     on<GetUserData>((event, emit) async {
-      final loginResponse = await actionClient.login(LoginRequest(),
-          options: sessionOptions(event.sessionId));
-      emit(UserDataLoaded(loginResponse.user, loginResponse.sessionId));
+      try {
+        final loginResponse = await actionClient.login(LoginRequest(),
+            options: sessionOptions(event.sessionId));
+        emit(UserDataLoaded(loginResponse.user, loginResponse.sessionId));
+      } catch (e) {
+        // Session invalid or expired
+        print(e);
+        emit(const UserLoggedOut(fromSplash: true));
+      }
     });
 
     on<UserLogIn>((event, emit) {

--- a/lib/blocs/user/user_bloc.dart
+++ b/lib/blocs/user/user_bloc.dart
@@ -23,11 +23,28 @@ class UserBloc extends HydratedBloc<UserEvent, UserState> {
   late String sessionId;
 
   UserBloc() : super(const UserLoggedOut()) {
+    on<CheckUser>((event, emit) async {
+      await Future.delayed(const Duration(milliseconds: 800));
+      if (state is UserLoggedIn) {
+        add(GetUserData(sessionId));
+      } else {
+        // go to login page
+        emit(const UserLoggedOut(showMsg: false));
+      }
+    });
+
+    on<GetUserData>((event, emit) async {
+      final loginResponse = await actionClient.login(LoginRequest(),
+          options: sessionOptions(event.sessionId));
+      emit(UserDataLoaded(loginResponse.user, loginResponse.sessionId));
+    });
+
     on<UserLogIn>((event, emit) {
       sessionId = event.loginResponse.sessionId;
-      emit(UserLoggedIn(
+      emit(UserDataLoaded(
           event.loginResponse.user, event.loginResponse.sessionId));
     });
+
     on<UserLogOut>((event, emit) {
       try {
         actionClient.logout(LogoutRequest(),
@@ -44,9 +61,8 @@ class UserBloc extends HydratedBloc<UserEvent, UserState> {
   @override
   UserState? fromJson(Map<String, dynamic> json) {
     try {
-      final user = User.fromJson(json['user']);
-      final sessionId = json['sessionId'];
-      return UserLoggedIn(user, sessionId);
+      sessionId = json['sessionId'];
+      return UserLoggedIn(sessionId);
     } catch (_) {
       return const UserLoggedOut();
     }
@@ -54,12 +70,10 @@ class UserBloc extends HydratedBloc<UserEvent, UserState> {
 
   @override
   Map<String, dynamic>? toJson(UserState state) {
-    if (state is UserLoggedIn) {
-      return {
-        'user': state.user.writeToJson(),
-        // TODO: Encrypt sessionId
-        'sessionId': state.sessionId,
-      };
+    if (state is UserDataLoaded) {
+      return {'sessionId': state.sessionId};
+    } else if (state is UserLoggedIn) {
+      return {'sessionId': state.sessionId};
     }
     return {};
   }

--- a/lib/blocs/user/user_event.dart
+++ b/lib/blocs/user/user_event.dart
@@ -7,6 +7,20 @@ abstract class UserEvent extends Equatable {
   List<Object> get props => [];
 }
 
+/// Should be called at splash screen
+class CheckUser extends UserEvent {
+  const CheckUser();
+}
+
+class GetUserData extends UserEvent {
+  final String sessionId;
+
+  const GetUserData(this.sessionId);
+
+  @override
+  List<Object> get props => [sessionId];
+}
+
 class UserLogIn extends UserEvent {
   final LoginResponse loginResponse;
 

--- a/lib/blocs/user/user_state.dart
+++ b/lib/blocs/user/user_state.dart
@@ -7,16 +7,40 @@ abstract class UserState extends Equatable {
   List<Object> get props => [];
 }
 
+/// User is logged out
+///
+/// Show Login Page
 class UserLoggedOut extends UserState {
-  const UserLoggedOut();
+  // Dont show msg only when comming from splash
+  final bool showMsg;
+
+  const UserLoggedOut({this.showMsg = true});
+
+  @override
+  List<Object> get props => [showMsg];
 }
 
+/// User is logged in but User data needs to fetched(already authenticated, just opened the app)
+///
+/// Show splash page and fetch user data, then go to home page
 class UserLoggedIn extends UserState {
+  final String sessionId;
+
+  const UserLoggedIn(this.sessionId);
+
+  @override
+  List<Object> get props => [sessionId];
+}
+
+/// User is logged in(user is currently using the app)
+///
+/// Show home page
+class UserDataLoaded extends UserState {
   final User user;
   final String sessionId;
 
-  const UserLoggedIn(this.user, this.sessionId);
+  const UserDataLoaded(this.user, this.sessionId);
 
   @override
-  List<Object> get props => [user, sessionId];
+  List<Object> get props => [sessionId, user];
 }

--- a/lib/blocs/user/user_state.dart
+++ b/lib/blocs/user/user_state.dart
@@ -11,13 +11,12 @@ abstract class UserState extends Equatable {
 ///
 /// Show Login Page
 class UserLoggedOut extends UserState {
-  // Dont show msg only when comming from splash
-  final bool showMsg;
+  final bool fromSplash;
 
-  const UserLoggedOut({this.showMsg = true});
+  const UserLoggedOut({this.fromSplash = false});
 
   @override
-  List<Object> get props => [showMsg];
+  List<Object> get props => [fromSplash];
 }
 
 /// User is logged in but User data needs to fetched(already authenticated, just opened the app)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -60,7 +60,8 @@ class DalalApp extends StatelessWidget {
               _navigator.pushNamedAndRemoveUntil('/home', (route) => false,
                   arguments: state.user);
             } else if (state is UserLoggedOut) {
-              if (state.showMsg) {
+              // Show msg only when comming from a page other than splash
+              if (!state.fromSplash) {
                 print('user logged out');
                 ScaffoldMessenger.of(context)
                   ..hideCurrentSnackBar()

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,7 +26,7 @@ void main() async {
 
   // Start the app
   runApp(
-    // Provide UserBloc at the root of the APp
+    // Provide UserBloc at the root of the App
     BlocProvider(
       create: (_) => UserBloc(),
       child: DalalApp(),
@@ -53,7 +53,7 @@ class DalalApp extends StatelessWidget {
       // Show snackbar and navigate to Home or Login page whenever UserState changes
       builder: (context, child) => BlocListener<UserBloc, UserState>(
         listener: (context, state) {
-          if (state is UserLoggedIn) {
+          if (state is UserDataLoaded) {
             print('user logged in');
             ScaffoldMessenger.of(context)
               ..hideCurrentSnackBar()
@@ -61,20 +61,21 @@ class DalalApp extends StatelessWidget {
                   SnackBar(content: Text('Welcome ${state.user.name}')));
             _navigator.pushNamedAndRemoveUntil('/home', (route) => false,
                 arguments: state.user);
-          } else {
-            print('user logged out');
-            ScaffoldMessenger.of(context)
-              ..hideCurrentSnackBar()
-              ..showSnackBar(const SnackBar(content: Text('User Logged Out')));
+          } else if (state is UserLoggedOut) {
+            if (state.showMsg) {
+              print('user logged out');
+              ScaffoldMessenger.of(context)
+                ..hideCurrentSnackBar()
+                ..showSnackBar(
+                    const SnackBar(content: Text('User Logged Out')));
+            }
             _navigator.pushNamedAndRemoveUntil('/login', (route) => false);
           }
         },
         child: child,
       ),
       // Routing
-      initialRoute: (userBloc.state is UserLoggedIn) ? '/home' : '/login',
-      onGenerateInitialRoutes: (initialRoute) =>
-          RouteGenerator.generateInitialRoute(initialRoute, userBloc.state),
+      initialRoute: '/splash',
       onGenerateRoute: RouteGenerator.generateRoute,
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,41 +42,38 @@ class DalalApp extends StatelessWidget {
   NavigatorState get _navigator => _navigatorKey.currentState!;
 
   @override
-  Widget build(context) {
-    final userBloc = context.read<UserBloc>();
-    return MaterialApp(
-      title: 'Dalal Street 2021',
-      navigatorKey: _navigatorKey,
-      debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-          textTheme: GoogleFonts.rubikTextTheme(Theme.of(context).textTheme)),
-      // Show snackbar and navigate to Home or Login page whenever UserState changes
-      builder: (context, child) => BlocListener<UserBloc, UserState>(
-        listener: (context, state) {
-          if (state is UserDataLoaded) {
-            print('user logged in');
-            ScaffoldMessenger.of(context)
-              ..hideCurrentSnackBar()
-              ..showSnackBar(
-                  SnackBar(content: Text('Welcome ${state.user.name}')));
-            _navigator.pushNamedAndRemoveUntil('/home', (route) => false,
-                arguments: state.user);
-          } else if (state is UserLoggedOut) {
-            if (state.showMsg) {
-              print('user logged out');
+  Widget build(context) => MaterialApp(
+        title: 'Dalal Street 2021',
+        navigatorKey: _navigatorKey,
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData(
+            textTheme: GoogleFonts.rubikTextTheme(Theme.of(context).textTheme)),
+        // Show snackbar and navigate to Home or Login page whenever UserState changes
+        builder: (context, child) => BlocListener<UserBloc, UserState>(
+          listener: (context, state) {
+            if (state is UserDataLoaded) {
+              print('user logged in');
               ScaffoldMessenger.of(context)
                 ..hideCurrentSnackBar()
                 ..showSnackBar(
-                    const SnackBar(content: Text('User Logged Out')));
+                    SnackBar(content: Text('Welcome ${state.user.name}')));
+              _navigator.pushNamedAndRemoveUntil('/home', (route) => false,
+                  arguments: state.user);
+            } else if (state is UserLoggedOut) {
+              if (state.showMsg) {
+                print('user logged out');
+                ScaffoldMessenger.of(context)
+                  ..hideCurrentSnackBar()
+                  ..showSnackBar(
+                      const SnackBar(content: Text('User Logged Out')));
+              }
+              _navigator.pushNamedAndRemoveUntil('/login', (route) => false);
             }
-            _navigator.pushNamedAndRemoveUntil('/login', (route) => false);
-          }
-        },
-        child: child,
-      ),
-      // Routing
-      initialRoute: '/splash',
-      onGenerateRoute: RouteGenerator.generateRoute,
-    );
-  }
+          },
+          child: child,
+        ),
+        // Routing
+        initialRoute: '/splash',
+        onGenerateRoute: RouteGenerator.generateRoute,
+      );
 }

--- a/lib/navigation/route_generator.dart
+++ b/lib/navigation/route_generator.dart
@@ -1,9 +1,9 @@
 // TODO: Need a better and simpler routing strategy
 
 import 'package:dalal_street_client/blocs/login/login_bloc.dart';
-import 'package:dalal_street_client/blocs/user/user_bloc.dart';
 import 'package:dalal_street_client/pages/auth/login_page.dart';
 import 'package:dalal_street_client/pages/home_page.dart';
+import 'package:dalal_street_client/pages/splash_page.dart';
 import 'package:dalal_street_client/proto_build/models/User.pb.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -13,6 +13,8 @@ class RouteGenerator {
     final args = settings.arguments;
 
     switch (settings.name) {
+      case '/splash':
+        return MaterialPageRoute(builder: (_) => const SplashPage());
       case '/login':
         return MaterialPageRoute(
             builder: (_) => BlocProvider(
@@ -27,17 +29,6 @@ class RouteGenerator {
       default:
         return _errorRoute();
     }
-  }
-
-  static List<Route<dynamic>> generateInitialRoute(
-      String initialRoutes, UserState userState) {
-    var routesList = [generateRoute(const RouteSettings(name: '/login'))];
-    if (userState is UserLoggedIn) {
-      routesList = [
-        generateRoute(RouteSettings(name: '/home', arguments: userState.user))
-      ];
-    }
-    return routesList;
   }
 
   static Route<dynamic> _errorRoute({String msg = 'Invalid Route'}) =>

--- a/lib/pages/splash_page.dart
+++ b/lib/pages/splash_page.dart
@@ -1,7 +1,20 @@
+import 'package:dalal_street_client/blocs/user/user_bloc.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/src/provider.dart';
 
-class SplashPage extends StatelessWidget {
+class SplashPage extends StatefulWidget {
   const SplashPage({Key? key}) : super(key: key);
+
+  @override
+  State<SplashPage> createState() => _SplashPageState();
+}
+
+class _SplashPageState extends State<SplashPage> {
+  @override
+  void initState() {
+    super.initState();
+    context.read<UserBloc>().add(const CheckUser());
+  }
 
   @override
   Widget build(context) => Scaffold(

--- a/lib/pages/splash_page.dart
+++ b/lib/pages/splash_page.dart
@@ -1,6 +1,6 @@
 import 'package:dalal_street_client/blocs/user/user_bloc.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/src/provider.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SplashPage extends StatefulWidget {
   const SplashPage({Key? key}) : super(key: key);

--- a/lib/pages/splash_page.dart
+++ b/lib/pages/splash_page.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class SplashPage extends StatelessWidget {
+  const SplashPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(context) => Scaffold(
+        body: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                'Dalal Street',
+                style: Theme.of(context)
+                    .textTheme
+                    .headline3
+                    ?.copyWith(color: Colors.blue),
+              ),
+              const SizedBox(height: 80),
+              const CircularProgressIndicator(),
+            ],
+          ),
+        ),
+      );
+}


### PR DESCRIPTION
### Auth Worflow:

- User opens App. First page is splash screen
- Splash screen checks for session id
    - If session id is null
        - Redirect to login page
   - If session id is not null
       - Get user details using session id
           - If error happens(session has expired) logout the user
           - else redirect to Home page

### States in `UserBloc`

- `UserLoggedOut` - User not authenticated
- `UserLoggedIn` - User is logged in but user data needs to fetched (user is already authenticated, just opened the app and is at splash screen)
- `UserDataLoaded` - User is logged in and  user data is loaded (user is currently using the app)

### Events in `UserBloc`

- `CheckUser` - Check for session id
- `GetUserData` - Get user data with the current session id
- `UserLogIn` - Data is loaded. show the home page
- `UserLogOut` - Clear session id and logout the user