### PR TITLE
Dependency Injection

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,7 +43,7 @@ import 'package:path_provider/path_provider.dart';
 /// // Can unregister with names
 /// getIt.unregister(instanceName: 'String 2');
 /// ```
-/// 
+///
 /// For more complex usecases checkout [get_it](https://pub.dev/packages/get_it)
 final GetIt getIt = GetIt.I;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,9 +5,12 @@ import 'package:dalal_street_client/navigation/route_generator.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:path_provider/path_provider.dart';
+
+final GetIt getIt = GetIt.I;
 
 void main() async {
   // Something doesnt work without this line. Dont remember what
@@ -52,6 +55,9 @@ class DalalApp extends StatelessWidget {
         builder: (context, child) => BlocListener<UserBloc, UserState>(
           listener: (context, state) {
             if (state is UserDataLoaded) {
+              // Register sessionId
+              getIt.registerSingleton(state.sessionId);
+
               print('user logged in');
               ScaffoldMessenger.of(context)
                 ..hideCurrentSnackBar()
@@ -60,8 +66,11 @@ class DalalApp extends StatelessWidget {
               _navigator.pushNamedAndRemoveUntil('/home', (route) => false,
                   arguments: state.user);
             } else if (state is UserLoggedOut) {
-              // Show msg only when comming from a page other than splash
               if (!state.fromSplash) {
+                // Unregister sessionId
+                getIt.unregister<String>();
+
+                // Show msg only when comming from a page other than splash
                 print('user logged out');
                 ScaffoldMessenger.of(context)
                   ..hideCurrentSnackBar()

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,41 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:path_provider/path_provider.dart';
 
+/// ## Dependency Injection
+///
+/// ### Registering objects
+/// #### Register objects to then read them from anywhere in the project
+/// ```dart
+/// // Most of the time getIt can differentiate between objects from thier Type
+/// getIt.registerSingleton<String>(sessionId);
+/// // Or like this, as type can be inferred in dart
+/// getIt.registerSingleton(sessionId);
+///
+/// // But if you have multiple objects of same type, then mention a name
+/// getIt.registerSingleton(sessionId);
+/// getIt.registerSingleton(someOtherString, instanceName: 'String 2');
+/// ```
+///
+/// ### Reading objects
+/// #### Warning: Trying to read unregistered objects will throw exception
+/// ```dart
+/// final sessionId = getIt<String>();
+/// // or
+/// final String sessionId = getIt();
+/// // reading objects registered with a name
+/// final String string2 = getIt(instanceName: 'String 2');
+/// ```
+///
+/// ### Unregistering objects
+/// ```dart
+/// // Unregister objects with thier type
+/// getIt.unregister<String>();
+/// getIt.unregister<User>();
+/// // Can unregister with names
+/// getIt.unregister(instanceName: 'String 2');
+/// ```
+/// 
+/// For more complex usecases checkout [get_it](https://pub.dev/packages/get_it)
 final GetIt getIt = GetIt.I;
 
 void main() async {

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,4 +1,5 @@
 import 'package:dalal_street_client/blocs/user/user_bloc.dart';
+import 'package:dalal_street_client/main.dart';
 import 'package:dalal_street_client/proto_build/models/User.pb.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -19,8 +20,9 @@ class HomePage extends StatelessWidget {
             child: Column(
               children: [
                 Text(
-                  'Current User: ${user.name}',
-                  style: const TextStyle(fontSize: 24),
+                  'Current User: ${user.name}\n Session Id: ${getIt<String>()}',
+                  style: const TextStyle(fontSize: 18),
+                  textAlign: TextAlign.center,
                 ),
                 ElevatedButton(
                   onPressed: () => _onLogoutClick(context),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -137,6 +137,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  get_it:
+    dependency: "direct main"
+    description:
+      name: get_it
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "7.2.0"
   google_fonts:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,9 @@ dependencies:
   # Needed for better state classes in Bloc
   equatable: ^2.0.3
 
+  # Dependency Injection
+  get_it: ^7.2.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Add dependency injection to easily access common data like `sessionId` across the app

Example usage is given in [main.dart](https://github.com/delta/dalal-street-client/blob/20086ff6971167bc0f8b1d53c049f8885dfbd1ce/lib/main.dart#L13-L47)

Note:
Everything has its purpose. Don't overuse dependency injection. For example don't use it to replace arguments in really simple navigation routes. Only use it to register common data which is needed across many pages. And take care of where stuff is being registered and unregistered to avoid exceptions.