### PR TITLE
[Add] global streams cubit

### DIFF
--- a/lib/blocs/auth/login/login_cubit.dart
+++ b/lib/blocs/auth/login/login_cubit.dart
@@ -1,7 +1,4 @@
 import 'package:bloc/bloc.dart';
-import 'package:dalal_street_client/blocs/streams/gamestate/gamestate_cubit.dart';
-import 'package:dalal_street_client/blocs/streams/notification/notification_cubit.dart';
-import 'package:dalal_street_client/blocs/streams/stockprice/stockprice_cubit.dart';
 import 'package:dalal_street_client/blocs/user/user_bloc.dart';
 import 'package:dalal_street_client/constants/error_messages.dart';
 import 'package:dalal_street_client/grpc/client.dart';
@@ -15,13 +12,8 @@ part 'login_state.dart';
 /// Handles the state for [LoginPage]
 class LoginCubit extends Cubit<LoginState> {
   final UserBloc userBloc;
-  final GamestateStreamCubit gamestateStreamCubit;
-  final NotificationStreamCubit notificationStreamCubit;
-  final StockpriceStreamCubit stockpriceStreamCubit;
 
-  LoginCubit(this.userBloc, this.gamestateStreamCubit,
-      this.notificationStreamCubit, this.stockpriceStreamCubit)
-      : super(LoginInitial());
+  LoginCubit(this.userBloc) : super(LoginInitial());
 
   Future<void> login(String email, String password) async {
     emit(const LoginLoading());
@@ -30,11 +22,6 @@ class LoginCubit extends Cubit<LoginState> {
           .login(LoginRequest(email: email, password: password));
       if (resp.statusCode == LoginResponse_StatusCode.OK) {
         emit(LoginSuccess(resp));
-
-        // starting global streams
-        await gamestateStreamCubit.start();
-        await notificationStreamCubit.start();
-        await stockpriceStreamCubit.start();
 
         userBloc.add(UserLogIn(resp));
       } else {

--- a/lib/blocs/streams/gamestate/gamestate_cubit.dart
+++ b/lib/blocs/streams/gamestate/gamestate_cubit.dart
@@ -9,10 +9,10 @@ import '../../../main.dart';
 
 part 'gamestate_state.dart';
 
-class GamestateCubit extends Cubit<GamestateStreamState> {
+class GamestateStreamCubit extends Cubit<GamestateStreamState> {
   late final Subscription subscription;
 
-  GamestateCubit() : super(GamestateStreamLoading()) {
+  GamestateStreamCubit() : super(GamestateStreamLoading()) {
     subscription = Subscription();
   }
 

--- a/lib/blocs/streams/gamestate/gamestate_cubit.dart
+++ b/lib/blocs/streams/gamestate/gamestate_cubit.dart
@@ -1,0 +1,48 @@
+import 'package:bloc/bloc.dart';
+import 'package:dalal_street_client/grpc/client.dart';
+import 'package:dalal_street_client/grpc/subscription.dart';
+import 'package:dalal_street_client/proto_build/datastreams/Subscribe.pb.dart';
+import 'package:dalal_street_client/proto_build/models/GameState.pb.dart';
+import 'package:equatable/equatable.dart';
+
+import '../../../main.dart';
+
+part 'gamestate_state.dart';
+
+class GamestateCubit extends Cubit<GamestateStreamState> {
+  late final Subscription subscription;
+
+  GamestateCubit() : super(GamestateStreamLoading()) {
+    subscription = Subscription();
+  }
+
+  // subscribe to gamestate stream and listen for updates
+  Future<void> start() async {
+    try {
+      final subscriptionId = await subscription.subscribe(
+          SubscribeRequest(dataStreamType: DataStreamType.GAME_STATE));
+
+      final gamestateStream = streamClient.getGameStateUpdates(subscriptionId,
+          options: sessionOptions(getIt<String>()));
+
+      // emitting success state after subscription
+      emit(GamestateStreamSuccess());
+
+      await for (final gamestate in gamestateStream) {
+        // emitting on each gamestate updates
+        emit(GamestateStreamUpdate(
+            gamestate.gameState, gamestate.gameState.type));
+      }
+    } catch (e) {
+      logger.e(e);
+      emit(GamestateStreamError(e.toString()));
+    }
+  }
+
+  @override
+  Future<void> close() {
+    // unsubscribing to notification stream
+    subscription.unSubscribe();
+    return super.close();
+  }
+}

--- a/lib/blocs/streams/gamestate/gamestate_state.dart
+++ b/lib/blocs/streams/gamestate/gamestate_state.dart
@@ -1,0 +1,25 @@
+part of 'gamestate_cubit.dart';
+
+abstract class GamestateStreamState extends Equatable {
+  const GamestateStreamState();
+
+  @override
+  List<Object> get props => [];
+}
+
+class GamestateStreamLoading extends GamestateStreamState {}
+
+class GamestateStreamSuccess extends GamestateStreamState {}
+
+class GamestateStreamUpdate extends GamestateStreamState {
+  final GameStateUpdateType gameStateUpdateType;
+  final GameState gamestate;
+
+  const GamestateStreamUpdate(this.gamestate, this.gameStateUpdateType);
+}
+
+class GamestateStreamError extends GamestateStreamState {
+  final String message;
+
+  const GamestateStreamError(this.message);
+}

--- a/lib/blocs/streams/notification/notification_cubit.dart
+++ b/lib/blocs/streams/notification/notification_cubit.dart
@@ -1,0 +1,47 @@
+import 'package:bloc/bloc.dart';
+import 'package:dalal_street_client/grpc/client.dart';
+import 'package:dalal_street_client/grpc/subscription.dart';
+import 'package:dalal_street_client/main.dart';
+import 'package:dalal_street_client/proto_build/datastreams/Subscribe.pb.dart';
+import 'package:dalal_street_client/proto_build/datastreams/Subscribe.pbenum.dart';
+import 'package:dalal_street_client/proto_build/models/Notification.pb.dart';
+import 'package:equatable/equatable.dart';
+
+part 'notification_state.dart';
+
+class NotificationStreamCubit extends Cubit<NotificationStreamState> {
+  late final Subscription subscription;
+  NotificationStreamCubit() : super(NotificationStreamLoading()) {
+    subscription = Subscription();
+  }
+  // subscribe to notification stream and listen for updates
+  Future<void> start() async {
+    try {
+      // subscribing to notification stream
+      final subscriptionId = await subscription.subscribe(
+          SubscribeRequest(dataStreamType: DataStreamType.NOTIFICATIONS));
+
+      final notificationStream = streamClient.getNotificationUpdates(
+          subscriptionId,
+          options: sessionOptions(getIt<String>()));
+
+      // emitting success state after subscription
+      emit(NotificationStreamSuccess());
+
+      await for (final notification in notificationStream) {
+        // emitting on each notification updates
+        emit(NotificationStreamUpdate(notification.notification));
+      }
+    } catch (e) {
+      logger.e(e);
+      emit(NotificationStreamError(e.toString()));
+    }
+  }
+
+  @override
+  Future<void> close() {
+    // unsubscribing to notification stream
+    subscription.unSubscribe();
+    return super.close();
+  }
+}

--- a/lib/blocs/streams/notification/notification_cubit.dart
+++ b/lib/blocs/streams/notification/notification_cubit.dart
@@ -3,7 +3,6 @@ import 'package:dalal_street_client/grpc/client.dart';
 import 'package:dalal_street_client/grpc/subscription.dart';
 import 'package:dalal_street_client/main.dart';
 import 'package:dalal_street_client/proto_build/datastreams/Subscribe.pb.dart';
-import 'package:dalal_street_client/proto_build/datastreams/Subscribe.pbenum.dart';
 import 'package:dalal_street_client/proto_build/models/Notification.pb.dart';
 import 'package:equatable/equatable.dart';
 

--- a/lib/blocs/streams/notification/notification_state.dart
+++ b/lib/blocs/streams/notification/notification_state.dart
@@ -1,0 +1,24 @@
+part of 'notification_cubit.dart';
+
+abstract class NotificationStreamState extends Equatable {
+  const NotificationStreamState();
+
+  @override
+  List<Object> get props => [];
+}
+
+class NotificationStreamLoading extends NotificationStreamState {}
+
+class NotificationStreamSuccess extends NotificationStreamState {}
+
+class NotificationStreamUpdate extends NotificationStreamState {
+  final Notification notification;
+
+  const NotificationStreamUpdate(this.notification);
+}
+
+class NotificationStreamError extends NotificationStreamState {
+  final String message;
+
+  const NotificationStreamError(this.message);
+}

--- a/lib/blocs/streams/stockprice/stockprice_cubit.dart
+++ b/lib/blocs/streams/stockprice/stockprice_cubit.dart
@@ -1,0 +1,47 @@
+import 'package:bloc/bloc.dart';
+import 'package:dalal_street_client/grpc/client.dart';
+import 'package:dalal_street_client/grpc/subscription.dart';
+import 'package:dalal_street_client/main.dart';
+import 'package:dalal_street_client/proto_build/datastreams/StockPrices.pb.dart';
+import 'package:dalal_street_client/proto_build/datastreams/Subscribe.pb.dart';
+import 'package:equatable/equatable.dart';
+
+part 'stockprice_state.dart';
+
+class StockpriceStreamCubit extends Cubit<StockpriceStreamState> {
+  late final Subscription subscription;
+
+  StockpriceStreamCubit() : super(StockpriceStreamLoading()) {
+    subscription = Subscription();
+  }
+
+  // subscribe to stock price stream and listen for updates
+  Future<void> start() async {
+    try {
+      // subscribing to stock prices stream
+      final subscriptionId = await subscription.subscribe(
+          SubscribeRequest(dataStreamType: DataStreamType.STOCK_PRICES));
+
+      final stockPriceStream =
+          streamClient.getStockPricesUpdates(subscriptionId);
+
+      // emitting [StockpriceStreamSuccess] after successful subscription to that stream
+      emit(StockpriceStreamSuccess());
+
+      await for (final stockPrices in stockPriceStream) {
+        // emitting stock prices on each updates from the server
+        emit(StockpriceStreamUpdate(stockPrices));
+      }
+    } catch (e) {
+      emit(StockpriceStreamError(e.toString()));
+      logger.e(e);
+    }
+  }
+
+  @override
+  Future<void> close() {
+    // unsubscribing to the stream
+    subscription.unSubscribe();
+    return super.close();
+  }
+}

--- a/lib/blocs/streams/stockprice/stockprice_state.dart
+++ b/lib/blocs/streams/stockprice/stockprice_state.dart
@@ -1,0 +1,24 @@
+part of 'stockprice_cubit.dart';
+
+abstract class StockpriceStreamState extends Equatable {
+  const StockpriceStreamState();
+
+  @override
+  List<Object> get props => [];
+}
+
+class StockpriceStreamLoading extends StockpriceStreamState {}
+
+class StockpriceStreamSuccess extends StockpriceStreamState {}
+
+class StockpriceStreamUpdate extends StockpriceStreamState {
+  final StockPricesUpdate stockPrices;
+
+  const StockpriceStreamUpdate(this.stockPrices);
+}
+
+class StockpriceStreamError extends StockpriceStreamState {
+  final String message;
+
+  const StockpriceStreamError(this.message);
+}

--- a/lib/blocs/user/user_bloc.dart
+++ b/lib/blocs/user/user_bloc.dart
@@ -1,3 +1,8 @@
+import 'dart:async';
+
+import 'package:dalal_street_client/blocs/streams/gamestate/gamestate_cubit.dart';
+import 'package:dalal_street_client/blocs/streams/notification/notification_cubit.dart';
+import 'package:dalal_street_client/blocs/streams/stockprice/stockprice_cubit.dart';
 import 'package:dalal_street_client/grpc/client.dart';
 import 'package:dalal_street_client/main.dart';
 import 'package:dalal_street_client/proto_build/actions/Login.pb.dart';
@@ -20,7 +25,50 @@ part 'user_state.dart';
 /// userBloc.add(const UserLogOut());
 /// ```
 class UserBloc extends HydratedBloc<UserEvent, UserState> {
-  UserBloc() : super(const UserLoggedOut()) {
+  final GamestateStreamCubit gamestateStreamCubit;
+  final StockpriceStreamCubit stockpriceStreamCubit;
+  final NotificationStreamCubit notificationStreamCubit;
+
+  late final StreamSubscription gamestateStreamSubscription;
+  late final StreamSubscription stockpriceStreamSubscription;
+  late final StreamSubscription notificationStreamSubscription;
+
+  bool globalStreamSubscriptionStatus = true;
+
+  UserBloc(this.gamestateStreamCubit, this.stockpriceStreamCubit,
+      this.notificationStreamCubit)
+      : super(const UserLoggedOut()) {
+    gamestateStreamSubscription = gamestateStreamCubit.stream.listen((state) {
+      if (state is GamestateStreamError) {
+        globalStreamSubscriptionStatus = false;
+      }
+
+      if (state is GamestateStreamSuccess) {
+        logger.i('success');
+      }
+    });
+
+    stockpriceStreamSubscription = stockpriceStreamCubit.stream.listen((state) {
+      if (state is StockpriceStreamError) {
+        globalStreamSubscriptionStatus = false;
+      }
+
+      if (state is StockpriceStreamSuccess) {
+        logger.i('success');
+      }
+    });
+
+    notificationStreamSubscription =
+        notificationStreamCubit.stream.listen((state) {
+      if (state is NotificationStreamError) {
+        globalStreamSubscriptionStatus = false;
+      }
+
+      if (state is NotificationStreamSuccess) {
+        logger.i('success');
+      }
+    });
+
     on<CheckUser>((event, emit) async {
       if (state is UserLoggedIn) {
         add(GetUserData((state as UserLoggedIn).sessionId));
@@ -36,16 +84,43 @@ class UserBloc extends HydratedBloc<UserEvent, UserState> {
       try {
         final loginResponse = await actionClient.login(LoginRequest(),
             options: sessionOptions(event.sessionId));
-        emit(UserDataLoaded(loginResponse.user, loginResponse.sessionId));
+
+        if (loginResponse.statusCode == LoginResponse_StatusCode.OK) {
+          // Register sessionId
+          getIt.registerSingleton(loginResponse.sessionId);
+
+          await _startGlobalStream();
+
+          // if global subscription fails
+          if (!globalStreamSubscriptionStatus) {
+            return emit(UserDataError());
+          }
+          logger.i('escaped');
+
+          emit(UserDataLoaded(loginResponse.user, loginResponse.sessionId));
+        }
       } catch (e) {
         // Session invalid or expired
         logger.e(e);
-        emit(const UserLoggedOut(fromSplash: true));
+        emit(UserDataError());
       }
     });
 
-    on<UserLogIn>((event, emit) => emit(UserDataLoaded(
-        event.loginResponse.user, event.loginResponse.sessionId)));
+    on<UserLogIn>((event, emit) async {
+      // Register sessionId
+      getIt.registerSingleton(event.loginResponse.sessionId);
+
+      await _startGlobalStream();
+      // if global subscription fails
+      if (!globalStreamSubscriptionStatus) {
+        return emit(UserDataError());
+      }
+
+      logger.i('escaped');
+
+      emit(UserDataLoaded(
+          event.loginResponse.user, event.loginResponse.sessionId));
+    });
 
     on<UserLogOut>((event, emit) {
       try {
@@ -77,5 +152,15 @@ class UserBloc extends HydratedBloc<UserEvent, UserState> {
       return {'sessionId': state.sessionId};
     }
     return {};
+  }
+
+  // method to subscribe all the global streams
+  Future<List<void>> _startGlobalStream() async {
+    // starting the global stream
+    return Future.wait([
+      gamestateStreamCubit.start(),
+      stockpriceStreamCubit.start(),
+      notificationStreamCubit.start()
+    ]);
   }
 }

--- a/lib/blocs/user/user_state.dart
+++ b/lib/blocs/user/user_state.dart
@@ -43,3 +43,9 @@ class UserDataLoaded extends UserState {
   @override
   List<Object> get props => [sessionId, user];
 }
+
+/// after UserLoggedIn state when there is any error in
+/// fetching user data or subscribing to global streams
+///
+/// redirect to Login Page
+class UserDataError extends UserState {}

--- a/lib/constants/exception.dart
+++ b/lib/constants/exception.dart
@@ -1,0 +1,3 @@
+final invalidDataStreamIdError = Exception('Invalid data stream id');
+final internalServerError = Exception('Internal server error');
+final failedToReachServerError = Exception('Unable reach the server');

--- a/lib/grpc/subscription.dart
+++ b/lib/grpc/subscription.dart
@@ -33,10 +33,9 @@ class Subscription {
         throw internalServerError;
       }
 
-      logger.d('[${_subscriptionId?.dataStreamType}]: subscribe successful');
-
       _subscriptionId = subscribeResponse.subscriptionId;
 
+      logger.d('[${_subscriptionId?.dataStreamType}]: subscribe successful');
       return _subscriptionId!;
     } catch (e) {
       logger.e(e);

--- a/lib/grpc/subscription.dart
+++ b/lib/grpc/subscription.dart
@@ -1,0 +1,69 @@
+import 'package:dalal_street_client/constants/exception.dart';
+import 'package:dalal_street_client/grpc/client.dart';
+import 'package:dalal_street_client/proto_build/datastreams/Subscribe.pb.dart';
+
+import '../main.dart';
+
+/// Subscription is used to handle subscribing and unsubscribing
+/// of grpc server server side streaming
+///
+/// [SubscriptionId] is used for unsubcribing and calling respected stream rpc
+///
+///  Flow
+///  - subscribe to a stream, return [SubscriptionId]
+///  - call the valid server side streaming rpc
+///  - unsubcribe to that stream, with [SubscriptionId]
+///
+/// creating instance of [Subscription] with bloc(stream) is encouraged
+class Subscription {
+  SubscriptionId? _subscriptionId;
+
+  Future<SubscriptionId> subscribe(SubscribeRequest subscribeRequest) async {
+    try {
+      final subscribeResponse = await streamClient.subscribe(subscribeRequest,
+          options: sessionOptions(getIt<String>()));
+
+      if (subscribeResponse.statusCode ==
+          SubscribeResponse_StatusCode.InvalidDataStreamId) {
+        throw invalidDataStreamIdError;
+      }
+
+      if (subscribeResponse.statusCode ==
+          SubscribeResponse_StatusCode.InternalServerError) {
+        throw internalServerError;
+      }
+
+      logger.d('[${_subscriptionId?.dataStreamType}]: subscribe successful');
+
+      _subscriptionId = subscribeResponse.subscriptionId;
+
+      return _subscriptionId!;
+    } catch (e) {
+      logger.e(e);
+      throw failedToReachServerError;
+    }
+  }
+
+  Future<void> unSubscribe() async {
+    try {
+      final unsubscribeResponse = await streamClient.unsubscribe(
+          UnsubscribeRequest(subscriptionId: _subscriptionId),
+          options: sessionOptions(getIt<String>()));
+
+      if (unsubscribeResponse.statusCode ==
+          UnsubscribeResponse_StatusCode.InvalidDataStreamId) {
+        throw invalidDataStreamIdError;
+      }
+
+      if (unsubscribeResponse.statusCode ==
+          UnsubscribeResponse_StatusCode.InternalServerError) {
+        throw internalServerError;
+      }
+
+      logger.d('[${_subscriptionId?.dataStreamType}]: unsubscribe successful');
+    } catch (e) {
+      logger.e(e);
+      throw failedToReachServerError;
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,6 @@
+import 'package:dalal_street_client/blocs/streams/gamestate/gamestate_cubit.dart';
+import 'package:dalal_street_client/blocs/streams/notification/notification_cubit.dart';
+import 'package:dalal_street_client/blocs/streams/stockprice/stockprice_cubit.dart';
 import 'package:dalal_street_client/blocs/user/user_bloc.dart';
 import 'package:dalal_street_client/config.dart';
 import 'package:dalal_street_client/grpc/client.dart';
@@ -70,8 +73,21 @@ void main() async {
   // Start the app
   runApp(
     // Provide UserBloc at the root of the App
-    BlocProvider(
-      create: (_) => UserBloc(),
+    MultiBlocProvider(
+      providers: [
+        BlocProvider(
+          create: (_) => UserBloc(),
+        ),
+        BlocProvider(
+          create: (context) => GamestateCubit(),
+        ),
+        BlocProvider(
+          create: (context) => NotificationStreamCubit(),
+        ),
+        BlocProvider(
+          create: (context) => StockpriceStreamCubit(),
+        ),
+      ],
       child: DalalApp(),
     ),
   );
@@ -102,7 +118,7 @@ class DalalApp extends StatelessWidget {
 
               logger.i('user logged in');
               if (state.user.isPhoneVerified) {
-                //showSnackBar(context, 'Welcome ${state.user.name}');
+                showSnackBar(context, 'Welcome ${state.user.name}');
                 _navigator.pushNamedAndRemoveUntil(
                   '/home',
                   (route) => false,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -76,9 +76,6 @@ void main() async {
     MultiBlocProvider(
       providers: [
         BlocProvider(
-          create: (_) => UserBloc(),
-        ),
-        BlocProvider(
           create: (context) => GamestateStreamCubit(),
         ),
         BlocProvider(
@@ -86,6 +83,10 @@ void main() async {
         ),
         BlocProvider(
           create: (context) => StockpriceStreamCubit(),
+        ),
+        BlocProvider(
+          create: (context) =>
+              UserBloc(context.read(), context.read(), context.read()),
         ),
       ],
       child: DalalApp(),
@@ -113,9 +114,6 @@ class DalalApp extends StatelessWidget {
         builder: (context, child) => BlocListener<UserBloc, UserState>(
           listener: (context, state) {
             if (state is UserDataLoaded) {
-              // Register sessionId
-              getIt.registerSingleton(state.sessionId);
-
               logger.i('user logged in');
               if (state.user.isPhoneVerified) {
                 showSnackBar(context, 'Welcome ${state.user.name}');
@@ -139,6 +137,15 @@ class DalalApp extends StatelessWidget {
                 showSnackBar(context, 'User Logged Out');
               }
               _navigator.pushNamedAndRemoveUntil('/landing', (route) => false);
+            } else if (state is UserDataError) {
+              logger.i('here');
+              // Unregister sessionId
+              getIt.unregister<String>();
+
+              showSnackBar(
+                  context, 'something went wrong, please try again later');
+
+              _navigator.pushNamedAndRemoveUntil('/login', (route) => false);
             }
           },
           child: child,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -79,7 +79,7 @@ void main() async {
           create: (_) => UserBloc(),
         ),
         BlocProvider(
-          create: (context) => GamestateCubit(),
+          create: (context) => GamestateStreamCubit(),
         ),
         BlocProvider(
           create: (context) => NotificationStreamCubit(),

--- a/lib/navigation/route_generator.dart
+++ b/lib/navigation/route_generator.dart
@@ -39,7 +39,8 @@ class RouteGenerator {
       // Auth Pages
       case '/login':
         return BlocProvider(
-          create: (context) => LoginCubit(context.read()),
+          create: (context) => LoginCubit(
+              context.read(), context.read(), context.read(), context.read()),
           child: LoginPage(),
         );
       case '/register':

--- a/lib/navigation/route_generator.dart
+++ b/lib/navigation/route_generator.dart
@@ -39,8 +39,7 @@ class RouteGenerator {
       // Auth Pages
       case '/login':
         return BlocProvider(
-          create: (context) => LoginCubit(
-              context.read(), context.read(), context.read(), context.read()),
+          create: (context) => LoginCubit(context.read()),
           child: LoginPage(),
         );
       case '/register':


### PR DESCRIPTION
- add gamestate, notification, stockprice stream cubit
- add in root level
- about states
   - all these cubits initial state will be [DATASTREAM_TYPE]StreamLoading
   - start method on these cubit will subscribe and listen for respected streams
   - after successful subscription [DATASTREAM_TYPE]StreamSuccess state will be emitted
   - on each update from server side rpc [DATASTREAM_TYPE]StreamUpdate will be emitted with respected data
   - close method on these cubit will unsubcribe to these streams

todo
 - need to subscribe to streams after user loggedIn
 - have to check if subscription is successful
 - add proper comments
 