### PR TITLE
[fix] [refactor] [auth]: getIt bug in registration

### DIFF
--- a/lib/blocs/auth/verify_phone/enter_otp/enter_otp_cubit.dart
+++ b/lib/blocs/auth/verify_phone/enter_otp/enter_otp_cubit.dart
@@ -48,7 +48,7 @@ class EnterOtpCubit extends Cubit<OtpState> {
       if (resp.statusCode == VerifyOTPResponse_StatusCode.OK) {
         emit(const OtpSuccess());
         // sessionId will be registered again in the root BlocListener
-        getIt.unregister<String>();
+        getIt.reset();
         dalalBloc.add(GetUserData(sessionId));
       } else {
         emit(OtpFailure(resp.statusMessage));

--- a/lib/blocs/dalal/dalal_bloc.dart
+++ b/lib/blocs/dalal/dalal_bloc.dart
@@ -47,6 +47,10 @@ class DalalBloc extends HydratedBloc<DalalEvent, DalalState> {
         if (loginResponse.statusCode != LoginResponse_StatusCode.OK) {
           throw Exception(loginResponse.statusMessage);
         }
+        if (!loginResponse.user.isPhoneVerified) {
+          emit(DalalVerificationPending(sessionId));
+          return;
+        }
         final globalStreams = await subscribeToGlobalStreams(
           loginResponse.user,
           sessionId,
@@ -73,12 +77,17 @@ class DalalBloc extends HydratedBloc<DalalEvent, DalalState> {
       }
     });
 
-    // TODO: DalalLogIn event and DalalDataLoaded state has the exact same data. Maybe some refactoring can be done?
-    on<DalalLogIn>((event, emit) => emit(DalalDataLoaded(
-          event.loginResponse.user,
-          event.loginResponse.sessionId,
-          event.globalStreams,
-        )));
+    on<DalalCheckVerification>((event, emit) async {
+      if (event.user.isPhoneVerified) {
+        emit(DalalDataLoaded(
+          event.user,
+          event.sessionId,
+          await subscribeToGlobalStreams(event.user, event.sessionId),
+        ));
+      } else {
+        emit(DalalVerificationPending(event.sessionId));
+      }
+    });
 
     on<DalalLogOut>((event, emit) {
       try {
@@ -113,6 +122,8 @@ class DalalBloc extends HydratedBloc<DalalEvent, DalalState> {
   @override
   Map<String, dynamic>? toJson(DalalState state) {
     if (state is DalalDataLoaded) {
+      return {'sessionId': state.sessionId};
+    } else if (state is DalalVerificationPending) {
       return {'sessionId': state.sessionId};
     } else if (state is DalalLoggedIn) {
       return {'sessionId': state.sessionId};

--- a/lib/blocs/dalal/dalal_bloc.dart
+++ b/lib/blocs/dalal/dalal_bloc.dart
@@ -37,7 +37,7 @@ class DalalBloc extends HydratedBloc<DalalEvent, DalalState> {
 
     on<GetUserData>((event, emit) async {
       final sessionId = event.sessionId;
-      emit(const DalalDataLoading());
+      emit(DalalDataLoading(sessionId));
       try {
         final loginResponse = await actionClient.login(
           LoginRequest(),
@@ -126,6 +126,8 @@ class DalalBloc extends HydratedBloc<DalalEvent, DalalState> {
     } else if (state is DalalVerificationPending) {
       return {'sessionId': state.sessionId};
     } else if (state is DalalLoggedIn) {
+      return {'sessionId': state.sessionId};
+    } else if (state is DalalDataLoading) {
       return {'sessionId': state.sessionId};
     } else if (state is DalalLoginFailed) {
       return {'sessionId': state.sessionId};

--- a/lib/blocs/dalal/dalal_event.dart
+++ b/lib/blocs/dalal/dalal_event.dart
@@ -7,7 +7,7 @@ abstract class DalalEvent extends Equatable {
   List<Object> get props => [];
 }
 
-/// Should be called at splash screen if sessionId is present
+/// Check if a sessionId is stored in local and redirect accordingly
 class CheckUser extends DalalEvent {
   const CheckUser();
 }
@@ -22,6 +22,7 @@ class GetUserData extends DalalEvent {
   List<Object> get props => [sessionId];
 }
 
+/// User has logged in by entering creds. Check verification and redirect accordingly
 class DalalCheckVerification extends DalalEvent {
   final User user;
   final String sessionId;
@@ -32,6 +33,7 @@ class DalalCheckVerification extends DalalEvent {
   List<Object> get props => [user, sessionId];
 }
 
+/// Logout the user
 class DalalLogOut extends DalalEvent {
   const DalalLogOut();
 }

--- a/lib/blocs/dalal/dalal_event.dart
+++ b/lib/blocs/dalal/dalal_event.dart
@@ -22,14 +22,14 @@ class GetUserData extends DalalEvent {
   List<Object> get props => [sessionId];
 }
 
-class DalalLogIn extends DalalEvent {
-  final LoginResponse loginResponse;
-  final GlobalStreams globalStreams;
+class DalalCheckVerification extends DalalEvent {
+  final User user;
+  final String sessionId;
 
-  const DalalLogIn(this.loginResponse, this.globalStreams);
+  const DalalCheckVerification(this.user, this.sessionId);
 
   @override
-  List<Object> get props => [loginResponse, globalStreams];
+  List<Object> get props => [user, sessionId];
 }
 
 class DalalLogOut extends DalalEvent {

--- a/lib/blocs/dalal/dalal_state.dart
+++ b/lib/blocs/dalal/dalal_state.dart
@@ -8,8 +8,6 @@ abstract class DalalState extends Equatable {
 }
 
 /// User is logged out
-///
-/// Show Login Page
 class DalalLoggedOut extends DalalState {
   final bool fromSplash;
 
@@ -20,8 +18,6 @@ class DalalLoggedOut extends DalalState {
 }
 
 /// User is logged in but User data needs to fetched(already authenticated, just opened the app)
-///
-/// Show splash page and fetch user data, then go to home page
 class DalalLoggedIn extends DalalState {
   final String sessionId;
 
@@ -31,10 +27,13 @@ class DalalLoggedIn extends DalalState {
   List<Object> get props => [sessionId];
 }
 
+/// Fetching user data with sessionId
 class DalalDataLoading extends DalalState {
+  // TODO: keep sessionId in this state too
   const DalalDataLoading();
 }
 
+/// User is logged in but verifiction is not done
 class DalalVerificationPending extends DalalState {
   final String sessionId;
 
@@ -45,8 +44,6 @@ class DalalVerificationPending extends DalalState {
 }
 
 /// User is logged in and verified
-///
-/// Show home page
 class DalalDataLoaded extends DalalState {
   final User user;
   final String sessionId;
@@ -62,9 +59,7 @@ class DalalDataLoaded extends DalalState {
   List<Object> get props => [user, sessionId, globalStreams];
 }
 
-/// When failure happens in getting user data
-///
-/// Stays in splash page. Shows snackbar with retry button
+/// Failure happened when getting user data
 class DalalLoginFailed extends DalalState {
   final String sessionId;
 

--- a/lib/blocs/dalal/dalal_state.dart
+++ b/lib/blocs/dalal/dalal_state.dart
@@ -29,8 +29,12 @@ class DalalLoggedIn extends DalalState {
 
 /// Fetching user data with sessionId
 class DalalDataLoading extends DalalState {
-  // TODO: keep sessionId in this state too
-  const DalalDataLoading();
+  final String sessionId;
+
+  const DalalDataLoading(this.sessionId);
+
+  @override
+  List<Object> get props => [sessionId];
 }
 
 /// User is logged in but verifiction is not done

--- a/lib/blocs/dalal/dalal_state.dart
+++ b/lib/blocs/dalal/dalal_state.dart
@@ -35,12 +35,20 @@ class DalalDataLoading extends DalalState {
   const DalalDataLoading();
 }
 
-/// User is logged in(user is currently using the app)
+class DalalVerificationPending extends DalalState {
+  final String sessionId;
+
+  const DalalVerificationPending(this.sessionId);
+
+  @override
+  List<Object> get props => [sessionId];
+}
+
+/// User is logged in and verified
 ///
 /// Show home page
 class DalalDataLoaded extends DalalState {
   final User user;
-  // Extra Data
   final String sessionId;
   final GlobalStreams globalStreams;
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -41,7 +41,6 @@ void main() async {
   );
 }
 
-// TODO: Fix getIt bug when registering
 // TODO: add proper validationMessages in all ReactiveForms
 // TODO: add metadata in all forms to facilitate Autofill
 // TODO: do that thing where if we hit enter while filling a form the focus will shift to the next textfield, and submits the form on hitting enter in the last field. Don't know what it's called

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -69,18 +69,18 @@ class DalalApp extends StatelessWidget {
               getIt.registerSingleton(state.globalStreams);
 
               logger.i('user logged in');
-              if (state.user.isPhoneVerified) {
-                //showSnackBar(context, 'Welcome ${state.user.name}');
-                _navigator.pushNamedAndRemoveUntil(
-                  '/home',
-                  (route) => false,
-                  arguments: state.user,
-                );
-              } else {
-                showSnackBar(context, 'Verify your phone to continue');
-                _navigator.pushNamedAndRemoveUntil(
-                    '/enterPhone', (route) => false);
-              }
+              _navigator.pushNamedAndRemoveUntil(
+                '/home',
+                (route) => false,
+                arguments: state.user,
+              );
+            } else if (state is DalalVerificationPending) {
+              // Register sessionId
+              getIt.registerSingleton(state.sessionId);
+
+              showSnackBar(context, 'Verify your phone to continue');
+              _navigator.pushNamedAndRemoveUntil(
+                  '/enterPhone', (route) => false);
             } else if (state is DalalLoggedOut) {
               // Unregister everything
               getIt.reset();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.8.1"
   bloc:
     dependency: "direct main"
     description:
@@ -42,7 +42,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
@@ -253,14 +253,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
-  material_color_utilities:
-    dependency: transitive
-    description:
-      name: material_color_utilities
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.2"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
@@ -468,7 +461,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
@@ -524,7 +517,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.0"
   win32:
     dependency: transitive
     description:


### PR DESCRIPTION
### Changes
- LoginCubit
  - dont subscribe to global streams here
  - add an event in `DalalBloc` to check verfication
- DalalBloc
  - on `GetUserData` event:
    - If user's phone is verified, emit `DalalDataLoaded`
    - If not, emit `DalalVerificationPending`
  - on `DalalCheckVerification` event:
    - same check as in `GetUserData` event
  - Store sessionId in `DalalDataLoading` state and persist it in toJson method of `HydratedBloc`
- Root dalal bloc listener
  - If state is `DalalDataLoaded`
    - register `sessionId` and `globalStreams` in getIt
    - go to `/home`
  - If state is `DalalVerificationPending`
    - register only `sessionId` in getIt
    - go to `/enterPhone`