### PR TITLE
[fix]: Fixed ParentDatawidget issue in NewsDetailsPage

### DIFF
--- a/lib/pages/company_page/components/news.dart
+++ b/lib/pages/company_page/components/news.dart
@@ -5,6 +5,7 @@ import 'package:dalal_street_client/config/log.dart';
 import 'package:dalal_street_client/pages/newsdetail_page.dart';
 import 'package:dalal_street_client/proto_build/models/MarketEvent.pb.dart';
 import 'package:dalal_street_client/theme/colors.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -68,8 +69,11 @@ class _CompanyNewsPageState extends State<CompanyNewsPage> {
                 ),
                 Padding(
                     padding: const EdgeInsets.fromLTRB(10, 0, 0, 0),
-                    child: Text(dur,
-                        style: const TextStyle(color: lightGray, fontSize: 12)))
+                    child: Text('Published on ' + dur,
+                        style: const TextStyle(
+                            fontStyle: FontStyle.italic,
+                            color: lightGray,
+                            fontSize: 12)))
               ]),
         ],
       ),
@@ -96,6 +100,8 @@ class _CompanyNewsPageState extends State<CompanyNewsPage> {
         if (state is GetNewsSucess) {
           mapMarketEvents.clear();
           mapMarketEvents.addAll(state.marketEventsList.marketEvents);
+          // Sort MarketEvents according to there created time
+          mapMarketEvents.sort((a, b) => b.createdAt.compareTo(a.createdAt));
           logger.i(mapMarketEvents);
           if (mapMarketEvents.isNotEmpty) {
             return ListView.separated(
@@ -113,7 +119,7 @@ class _CompanyNewsPageState extends State<CompanyNewsPage> {
                     child: newsItem(headline, imagePath, createdAt),
                     onTap: () => Navigator.push(
                         context,
-                        MaterialPageRoute(
+                        CupertinoPageRoute(
                           builder: (context) => NewsDetail(
                               text: text,
                               imagePath: imagePath,

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -12,6 +12,7 @@ import 'package:dalal_street_client/proto_build/models/Stock.pb.dart';
 import 'package:dalal_street_client/proto_build/models/User.pb.dart';
 import 'package:dalal_street_client/streams/global_streams.dart';
 import 'package:dalal_street_client/utils/responsive.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:dalal_street_client/theme/colors.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -146,6 +147,8 @@ class _HomePageState extends State<HomePage>
         if (state is GetNewsSucess) {
           mapMarketEvents.clear();
           mapMarketEvents.addAll(state.marketEventsList.marketEvents);
+          // Sort MarketEvents according to there created time
+          mapMarketEvents.sort((a, b) => b.createdAt.compareTo(a.createdAt));
           if (mapMarketEvents.isNotEmpty) {
             return ListView.separated(
               shrinkWrap: true,
@@ -162,7 +165,7 @@ class _HomePageState extends State<HomePage>
                     child: newsItem(headline, imagePath, createdAt),
                     onTap: () => Navigator.push(
                         context,
-                        MaterialPageRoute(
+                        CupertinoPageRoute(
                           builder: (context) => NewsDetail(
                               text: text,
                               imagePath: imagePath,
@@ -305,8 +308,11 @@ class _HomePageState extends State<HomePage>
                 ),
                 Padding(
                     padding: const EdgeInsets.fromLTRB(10, 0, 0, 0),
-                    child: Text(dur,
-                        style: const TextStyle(color: lightGray, fontSize: 12)))
+                    child: Text('Published on ' + dur,
+                        style: const TextStyle(
+                            fontStyle: FontStyle.italic,
+                            color: lightGray,
+                            fontSize: 12)))
               ]),
         ],
       ),

--- a/lib/pages/news_page.dart
+++ b/lib/pages/news_page.dart
@@ -6,6 +6,7 @@ import 'package:dalal_street_client/pages/newsdetail_page.dart';
 import 'package:dalal_street_client/proto_build/datastreams/Subscribe.pb.dart';
 import 'package:dalal_street_client/proto_build/models/MarketEvent.pb.dart';
 import 'package:dalal_street_client/theme/colors.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -98,7 +99,7 @@ class _NewsPageState extends State<NewsPage> {
                   child: newsItem(headline, imagePath, createdAt, false),
                   onTap: () => Navigator.push(
                       context,
-                      MaterialPageRoute(
+                      CupertinoPageRoute(
                         builder: (context) => NewsDetail(
                             text: text,
                             imagePath: imagePath,
@@ -336,9 +337,11 @@ class _NewsPageState extends State<NewsPage> {
                   ),
                   Padding(
                       padding: const EdgeInsets.fromLTRB(10, 0, 0, 0),
-                      child: Text(dur,
-                          style:
-                              const TextStyle(color: lightGray, fontSize: 12)))
+                      child: Text('Published on ' + dur,
+                          style: const TextStyle(
+                              fontStyle: FontStyle.italic,
+                              color: lightGray,
+                              fontSize: 12)))
                 ]),
           ],
         ),
@@ -363,9 +366,11 @@ class _NewsPageState extends State<NewsPage> {
                       const SizedBox.square(
                         dimension: 5,
                       ),
-                      Text(dur,
-                          style:
-                              const TextStyle(color: lightGray, fontSize: 12)),
+                      Text('Published on ' + dur,
+                          style: const TextStyle(
+                              fontStyle: FontStyle.italic,
+                              color: lightGray,
+                              fontSize: 12))
                     ]),
                 const SizedBox.square(
                   dimension: 20,

--- a/lib/pages/newsdetail_page.dart
+++ b/lib/pages/newsdetail_page.dart
@@ -53,34 +53,25 @@ class NewsDetail extends StatelessWidget {
             )),
             Padding(
               padding: const EdgeInsets.all(15),
-              child: Flexible(
-                child: Text(
-                  dur,
-                  style: const TextStyle(fontSize: 12, color: lightGray),
-                ),
-                fit: FlexFit.loose,
+              child: Text(
+                dur,
+                style: const TextStyle(fontSize: 12, color: lightGray),
               ),
             ),
             Padding(
               padding: const EdgeInsets.all(15),
-              child: Flexible(
-                child: Text(
-                  headline,
-                  style: const TextStyle(
-                      fontSize: 18, fontWeight: FontWeight.bold),
-                ),
-                fit: FlexFit.loose,
+              child: Text(
+                headline,
+                style:
+                    const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
               ),
             ),
             Padding(
               padding: const EdgeInsets.all(15),
-              child: Flexible(
-                child: Text(
-                  text,
-                  textAlign: TextAlign.start,
-                  style: const TextStyle(fontSize: 16, color: lightGray),
-                ),
-                fit: FlexFit.loose,
+              child: Text(
+                text,
+                textAlign: TextAlign.start,
+                style: const TextStyle(fontSize: 16, color: lightGray),
               ),
             )
           ]),

--- a/lib/pages/newsdetail_page.dart
+++ b/lib/pages/newsdetail_page.dart
@@ -52,12 +52,12 @@ class NewsDetail extends StatelessWidget {
               ),
             )),
             Padding(
-              padding: const EdgeInsets.all(15),
-              child: Text(
-                dur,
-                style: const TextStyle(fontSize: 12, color: lightGray),
-              ),
-            ),
+                padding: const EdgeInsets.all(15),
+                child: Text('Published on ' + dur,
+                    style: const TextStyle(
+                        fontStyle: FontStyle.italic,
+                        color: lightGray,
+                        fontSize: 12))),
             Padding(
               padding: const EdgeInsets.all(15),
               child: Text(


### PR DESCRIPTION
In this PR :
- Fixed `Incorrect Use of ParentDataWidget`
- This error was caused because Flexible was used inside Padding and Center but Flexible should be strictly used inside Column or Row only 
- Added ordering and Updated UI
![image](https://user-images.githubusercontent.com/59143264/153913161-611aa22e-bb4b-4a5b-8a44-e961b7748e68.png)
