### PR TITLE
[fix] [route]: bug in /company route

### DIFF
--- a/lib/navigation/dalal_nav_buidler.dart
+++ b/lib/navigation/dalal_nav_buidler.dart
@@ -49,7 +49,8 @@ class _DalalNavBuilderState extends State<DalalNavBuilder> {
             if (!homeRoutesWeb.contains(widget.routerState.location) &&
                 !otherNonAuthRoutes.hasMatch(widget.routerState.location)) {
               context.webGo('/home');
-              logger.i('Redirecting to /home from ${widget.routerState.location}');
+              logger.i(
+                  'Redirecting to /home from ${widget.routerState.location}');
             } else {
               // Redirect to the same route, without adding to web history
               // Originally state will not be DalalDataLoaded, so exception will happen

--- a/lib/navigation/dalal_nav_buidler.dart
+++ b/lib/navigation/dalal_nav_buidler.dart
@@ -5,6 +5,7 @@ import 'package:dalal_street_client/config/log.dart';
 import 'package:dalal_street_client/models/snackbar/snackbar_type.dart';
 import 'package:dalal_street_client/navigation/home_routes.dart';
 import 'package:dalal_street_client/navigation/nav_utils.dart';
+import 'package:dalal_street_client/utils/regex_util.dart';
 import 'package:dalal_street_client/utils/snackbar.dart';
 import 'package:dalal_street_client/utils/stream_snackbar.dart';
 import 'package:flutter/material.dart';
@@ -45,11 +46,10 @@ class _DalalNavBuilderState extends State<DalalNavBuilder> {
 
             logger.i('user logged in');
 
-            // TODO: handle redirect for /company/:id
             if (!homeRoutesWeb.contains(widget.routerState.location) &&
-                !otherNonAuthRoutes.contains(widget.routerState.name)) {
+                !otherNonAuthRoutes.hasMatch(widget.routerState.location)) {
               context.webGo('/home');
-              logger.d('Redirect to home from ${widget.routerState.name}');
+              logger.i('Redirecting to /home from ${widget.routerState.location}');
             } else {
               // Redirect to the same route, without adding to web history
               // Originally state will not be DalalDataLoaded, so exception will happen
@@ -57,7 +57,6 @@ class _DalalNavBuilderState extends State<DalalNavBuilder> {
               // Now the state has required data, so router can again direct to the required page
               //
               // Hacky fix, but no other way possible unless the routing lib gives a dedicated api for async loading of data
-              logger.d('Redirect to same location');
               context.webGo(
                 widget.routerState.location,
                 extra: widget.routerState.extra,

--- a/lib/navigation/dalal_nav_buidler.dart
+++ b/lib/navigation/dalal_nav_buidler.dart
@@ -45,9 +45,11 @@ class _DalalNavBuilderState extends State<DalalNavBuilder> {
 
             logger.i('user logged in');
 
+            // TODO: handle redirect for /company/:id
             if (!homeRoutesWeb.contains(widget.routerState.location) &&
-                !otherNonAuthRoutes.contains(widget.routerState.location)) {
+                !otherNonAuthRoutes.contains(widget.routerState.name)) {
               context.webGo('/home');
+              logger.d('Redirect to home from ${widget.routerState.name}');
             } else {
               // Redirect to the same route, without adding to web history
               // Originally state will not be DalalDataLoaded, so exception will happen
@@ -55,6 +57,7 @@ class _DalalNavBuilderState extends State<DalalNavBuilder> {
               // Now the state has required data, so router can again direct to the required page
               //
               // Hacky fix, but no other way possible unless the routing lib gives a dedicated api for async loading of data
+              logger.d('Redirect to same location');
               context.webGo(
                 widget.routerState.location,
                 extra: widget.routerState.extra,

--- a/lib/navigation/home_routes.dart
+++ b/lib/navigation/home_routes.dart
@@ -53,7 +53,7 @@ final moreRoutesMobile = moreMenuMobile.keys.toList();
 final homeRoutesWeb = homeRoutesMobile + moreRoutesMobile;
 
 /// Routes not directly in home page, but accesed by only authenticated users
-final otherNonAuthRoutes = ['company'];
+final otherNonAuthRoutes = ['/company/:id'];
 
 /// Widgets for routes in more section in mobile
 Map<String, Widget> mobileHomePagesMore(User extra) => {

--- a/lib/navigation/home_routes.dart
+++ b/lib/navigation/home_routes.dart
@@ -53,7 +53,7 @@ final moreRoutesMobile = moreMenuMobile.keys.toList();
 final homeRoutesWeb = homeRoutesMobile + moreRoutesMobile;
 
 /// Routes not directly in home page, but accesed by only authenticated users
-final otherNonAuthRoutes = ['/company'];
+final otherNonAuthRoutes = ['company'];
 
 /// Widgets for routes in more section in mobile
 Map<String, Widget> mobileHomePagesMore(User extra) => {

--- a/lib/navigation/router.dart
+++ b/lib/navigation/router.dart
@@ -65,19 +65,21 @@ GoRouter generateRouter(BuildContext context) => GoRouter(
             return mobileExtras[location]!;
           },
         ),
-        // TODO: can do params
-        // Example: /company/1
-        // Link: https://gorouter.dev/parameters
         GoRoute(
-          path: '/company',
-          builder: (_, state) => MultiBlocProvider(
-            providers: [
-              BlocProvider(create: (_) => MarketDepthBloc()),
-              BlocProvider(create: (_) => SubscribeCubit()),
-              BlocProvider(create: (_) => NewsBloc()),
-            ],
-            child: CompanyPage(data: state.extra! as List<int>),
-          ),
+          path: '/company/:id',
+          name: 'company',
+          builder: (_, state) {
+            // TODO: handle for invalid stockId and no stockId
+            final stockId = int.parse(state.params['id']!);
+            return MultiBlocProvider(
+              providers: [
+                BlocProvider(create: (_) => MarketDepthBloc()),
+                BlocProvider(create: (_) => SubscribeCubit()),
+                BlocProvider(create: (_) => NewsBloc()),
+              ],
+              child: CompanyPage(stockId: stockId),
+            );
+          },
         )
       ],
       // Show snackbar and navigate to Home or Login page whenever UserState changes

--- a/lib/navigation/router.dart
+++ b/lib/navigation/router.dart
@@ -8,6 +8,7 @@ import 'package:dalal_street_client/blocs/dalal/dalal_bloc.dart';
 import 'package:dalal_street_client/blocs/market_depth/market_depth_bloc.dart';
 import 'package:dalal_street_client/blocs/news/news_bloc.dart';
 import 'package:dalal_street_client/blocs/subscribe/subscribe_cubit.dart';
+import 'package:dalal_street_client/config/get_it.dart';
 import 'package:dalal_street_client/navigation/dalal_nav_buidler.dart';
 import 'package:dalal_street_client/navigation/home_routes.dart';
 import 'package:dalal_street_client/pages/admin_page/admin_page.dart';
@@ -24,6 +25,7 @@ import 'package:dalal_street_client/pages/auth/register_page.dart';
 import 'package:dalal_street_client/pages/auth/verify_phone/enter_otp_page.dart';
 import 'package:dalal_street_client/pages/auth/verify_phone/enter_phone_page.dart';
 import 'package:dalal_street_client/pages/landing_page.dart';
+import 'package:dalal_street_client/streams/global_streams.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -69,8 +71,17 @@ GoRouter generateRouter(BuildContext context) => GoRouter(
           path: '/company/:id',
           name: 'company',
           builder: (_, state) {
-            // TODO: handle for invalid stockId and no stockId
-            final stockId = int.parse(state.params['id']!);
+            final stockId = int.tryParse(state.params['id']!);
+            if (stockId == null) {
+              throw Exception('Invalid company id');
+            }
+
+            final stockIds =
+                getIt<GlobalStreams>().latestStockMap.keys.toList();
+            if (!stockIds.contains(stockId)) {
+              throw Exception('Company with id $stockId doesn\'t exist');
+            }
+
             return MultiBlocProvider(
               providers: [
                 BlocProvider(create: (_) => MarketDepthBloc()),

--- a/lib/pages/company_page/company_page.dart
+++ b/lib/pages/company_page/company_page.dart
@@ -17,8 +17,9 @@ import 'package:intl/intl.dart';
 final oCcy = NumberFormat('#,##0.00', 'en_US');
 
 class CompanyPage extends StatefulWidget {
-  final List<int> data;
-  const CompanyPage({Key? key, required this.data}) : super(key: key);
+  final int stockId;
+
+  const CompanyPage({Key? key, required this.stockId}) : super(key: key);
 
   @override
   State<CompanyPage> createState() => _CompanyPageState();
@@ -33,15 +34,16 @@ class _CompanyPageState extends State<CompanyPage>
     super.initState();
     // Subscribe to the stream of Market Depth Updates
     context.read<SubscribeCubit>().subscribe(DataStreamType.MARKET_DEPTH,
-        dataStreamId: widget.data[0].toString());
+        dataStreamId: widget.stockId.toString());
   }
 
   @override
   // ignore: must_call_super
   Widget build(BuildContext context) {
-    final stockList = getIt<GlobalStreams>().latestStockMap;
-    final int stockId = widget.data.first;
-    final int cash = widget.data.last;
+    final globalStreams = getIt<GlobalStreams>();
+    final stockList = globalStreams.latestStockMap;
+    final int stockId = widget.stockId;
+    final int cash = globalStreams.latestUserInfo.cash;
     Stock company = stockList[stockId]!;
     return SafeArea(
       child: Responsive(
@@ -67,7 +69,7 @@ class _CompanyPageState extends State<CompanyPage>
                       const SizedBox(
                         height: 10,
                       ),
-                      CompanyNewsPage(stockId: widget.data.first)
+                      CompanyNewsPage(stockId: stockId)
                     ])),
                 // Hide Place Order Button if company went Bankrupt
                 company.isBankrupt

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -354,15 +354,8 @@ class StockItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    int cash = getIt<GlobalStreams>().dynamicUserInfoStream.value.cash;
-    List<int> data = [stock.id, cash];
     return GestureDetector(
-      onTap: () {
-        context.push(
-          '/company',
-          extra: data,
-        );
-      },
+      onTap: () => context.push('/company/${stock.id}'),
       child: Container(
           padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20),
           child: Row(mainAxisAlignment: MainAxisAlignment.start, children: [

--- a/lib/pages/mortgage/mortgage_page.dart
+++ b/lib/pages/mortgage/mortgage_page.dart
@@ -41,12 +41,5 @@ class _MortgagePageState extends State<MortgagePage> {
     );
   }
 
-  void _navigateToCompanyPage(int stockId) {
-    int cash = getIt<GlobalStreams>().dynamicUserInfoStream.value.cash;
-    List<int> data = [stockId, cash];
-    context.push(
-      '/company',
-      extra: data,
-    );
-  }
+  void _navigateToCompanyPage(int stockId) => context.push('/company/$stockId');
 }

--- a/lib/pages/mortgage/retrieve_page.dart
+++ b/lib/pages/mortgage/retrieve_page.dart
@@ -71,12 +71,5 @@ class _RetrievePageState extends State<RetrievePage> {
     );
   }
 
-  void _navigateToCompanyPage(int stockId) {
-    int cash = getIt<GlobalStreams>().dynamicUserInfoStream.value.cash;
-    List<int> data = [stockId, cash];
-    context.push(
-      '/company',
-      extra: data,
-    );
-  }
+  void _navigateToCompanyPage(int stockId) => context.push('/company/$stockId');
 }

--- a/lib/pages/stock_exchange/exchange_page.dart
+++ b/lib/pages/stock_exchange/exchange_page.dart
@@ -243,12 +243,5 @@ class _ExchangePageState extends State<ExchangePage>
     );
   }
 
-  void _navigateToCompanyPage(int stockId) {
-    int cash = getIt<GlobalStreams>().dynamicUserInfoStream.value.cash;
-    List<int> data = [stockId, cash];
-    context.push(
-      '/company',
-      extra: data,
-    );
-  }
+  void _navigateToCompanyPage(int stockId) => context.push('/company/$stockId');
 }

--- a/lib/utils/regex_util.dart
+++ b/lib/utils/regex_util.dart
@@ -1,0 +1,11 @@
+import 'package:path_to_regexp/path_to_regexp.dart';
+
+extension RegexUtil on List<String> {
+  bool hasMatch(String path) {
+    for (var item in this) {
+      final regex = pathToRegExp(item);
+      if (regex.hasMatch(path)) return true;
+    }
+    return false;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -395,7 +395,7 @@ packages:
     source: hosted
     version: "2.0.5"
   path_to_regexp:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_to_regexp
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,8 @@ dependencies:
 
   # Navigation
   go_router: ^3.0.1
+  # Helper for matching path regex
+  path_to_regexp: ^0.4.0
 
   # Form Validation
   reactive_forms: ^10.6.5


### PR DESCRIPTION
### Changes
- Refactored `/company` to `/company/:id` (see [comment](https://github.com/delta/dalal-street-client/pull/86#issuecomment-1047448311) for why)
  - Company page accepts stockId in route, instead of in extras
  - Company page doesn't need `userCash` as extra anymore, reads it from `getIt`

### Features
- Handle errors when id in `/company/:id` is:
  - Not an integer
  - Not an existing company