### PR TITLE
[feat] [ui]: change how daily challenges open state is shown in ui

### DIFF
--- a/lib/blocs/daily_challenges/daily_challenges_page_cubit.dart
+++ b/lib/blocs/daily_challenges/daily_challenges_page_cubit.dart
@@ -2,10 +2,8 @@ import 'package:bloc/bloc.dart';
 import 'package:dalal_street_client/config/get_it.dart';
 import 'package:dalal_street_client/config/log.dart';
 import 'package:dalal_street_client/constants/error_messages.dart';
-import 'package:dalal_street_client/streams/global_streams.dart';
 import 'package:dalal_street_client/grpc/client.dart';
 import 'package:dalal_street_client/proto_build/actions/GetDailyChallengeConfig.pb.dart';
-import 'package:dalal_street_client/proto_build/models/GameState.pbenum.dart';
 import 'package:equatable/equatable.dart';
 
 part 'daily_challenges_page_state.dart';
@@ -21,32 +19,16 @@ class DailyChallengesPageCubit extends Cubit<DailyChallengesPageState> {
       );
       if (resp.statusCode == GetDailyChallengeConfigResponse_StatusCode.OK) {
         emit(DailyChallengesPageSuccess(
+          resp.isDailyChallengOpen,
           resp.marketDay,
           resp.totalMarketDays,
         ));
-        listenToGameStateStream();
       } else {
         emit(DailyChallengesPageFailure(resp.statusMessage));
       }
     } catch (e) {
       logger.e(e);
       emit(const DailyChallengesPageFailure(failedToReachServer));
-    }
-  }
-
-  /// Only call this after [getChallengesConfig] is succesful
-  Future<void> listenToGameStateStream() async {
-    final gameStateStream = getIt<GlobalStreams>().gameStateStream;
-    await for (var update in gameStateStream) {
-      final gameState = update.gameState;
-      if (gameState.type == GameStateUpdateType.DailyChallengeStatusUpdate) {
-        try {
-          // TODO: handle separately from DailyChallengesPageSuccess state
-          // final success = state as DailyChallengesPageSuccess;
-        } catch (e) {
-          logger.e(e);
-        }
-      }
     }
   }
 }

--- a/lib/blocs/daily_challenges/daily_challenges_page_cubit.dart
+++ b/lib/blocs/daily_challenges/daily_challenges_page_cubit.dart
@@ -22,7 +22,6 @@ class DailyChallengesPageCubit extends Cubit<DailyChallengesPageState> {
       if (resp.statusCode == GetDailyChallengeConfigResponse_StatusCode.OK) {
         emit(DailyChallengesPageSuccess(
           resp.marketDay,
-          resp.isDailyChallengOpen,
           resp.totalMarketDays,
         ));
         listenToGameStateStream();
@@ -35,7 +34,6 @@ class DailyChallengesPageCubit extends Cubit<DailyChallengesPageState> {
     }
   }
 
-  /// Updates `isDailyChallengeOpen` in [DailyChallengesPageSuccess]
   /// Only call this after [getChallengesConfig] is succesful
   Future<void> listenToGameStateStream() async {
     final gameStateStream = getIt<GlobalStreams>().gameStateStream;
@@ -43,12 +41,8 @@ class DailyChallengesPageCubit extends Cubit<DailyChallengesPageState> {
       final gameState = update.gameState;
       if (gameState.type == GameStateUpdateType.DailyChallengeStatusUpdate) {
         try {
-          final success = state as DailyChallengesPageSuccess;
-          emit(DailyChallengesPageSuccess(
-            success.marketDay,
-            gameState.dailyChallengeState.isDailyChallengeOpen,
-            success.totalMarketDays,
-          ));
+          // TODO: handle separately from DailyChallengesPageSuccess state
+          // final success = state as DailyChallengesPageSuccess;
         } catch (e) {
           logger.e(e);
         }

--- a/lib/blocs/daily_challenges/daily_challenges_page_state.dart
+++ b/lib/blocs/daily_challenges/daily_challenges_page_state.dart
@@ -11,17 +11,15 @@ class DailyChallengesPageLoading extends DailyChallengesPageState {}
 
 class DailyChallengesPageSuccess extends DailyChallengesPageState {
   final int marketDay;
-  final bool isDailyChallengesOpen;
   final int totalMarketDays;
 
   const DailyChallengesPageSuccess(
     this.marketDay,
-    this.isDailyChallengesOpen,
     this.totalMarketDays,
   );
 
   @override
-  List<Object> get props => [marketDay, isDailyChallengesOpen, totalMarketDays];
+  List<Object> get props => [marketDay, totalMarketDays];
 }
 
 class DailyChallengesPageFailure extends DailyChallengesPageState {

--- a/lib/blocs/daily_challenges/daily_challenges_page_state.dart
+++ b/lib/blocs/daily_challenges/daily_challenges_page_state.dart
@@ -10,16 +10,18 @@ abstract class DailyChallengesPageState extends Equatable {
 class DailyChallengesPageLoading extends DailyChallengesPageState {}
 
 class DailyChallengesPageSuccess extends DailyChallengesPageState {
+  final bool isChallengesOpen;
   final int marketDay;
   final int totalMarketDays;
 
   const DailyChallengesPageSuccess(
+    this.isChallengesOpen,
     this.marketDay,
     this.totalMarketDays,
   );
 
   @override
-  List<Object> get props => [marketDay, totalMarketDays];
+  List<Object> get props => [isChallengesOpen, marketDay, totalMarketDays];
 }
 
 class DailyChallengesPageFailure extends DailyChallengesPageState {

--- a/lib/pages/daily_challenges/components/daily_challenge_item.dart
+++ b/lib/pages/daily_challenges/components/daily_challenge_item.dart
@@ -12,7 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class DailyChallengeItem extends StatelessWidget {
-  final int marketDay;
+  final bool isCurrentDay;
 
   final DailyChallenge challenge;
   final UserState userState;
@@ -20,7 +20,7 @@ class DailyChallengeItem extends StatelessWidget {
 
   DailyChallengeItem({
     Key? key,
-    required this.marketDay,
+    required this.isCurrentDay,
     required this.challenge,
     required this.userState,
     required this.stock,
@@ -83,10 +83,9 @@ class DailyChallengeItem extends StatelessWidget {
         ),
       );
 
-  // TODO: add progress bar
   // TODO: animate between changes in userInfoStream
   Widget _challengeProgress() {
-    if (challenge.marketDay != marketDay) {
+    if (!isCurrentDay) {
       return ChallengeProgress(
         progress: (userState.finalValue - userState.initialValue).toInt(),
         targetValue: challenge.value.toInt(),

--- a/lib/pages/daily_challenges/daily_challenges_page.dart
+++ b/lib/pages/daily_challenges/daily_challenges_page.dart
@@ -110,7 +110,7 @@ class _DailyChallengesPageBodyState extends State<_DailyChallengesPageBody>
                     create: (_) => SingleDayChallengesCubit(),
                     child: SingleDayChallenges(
                       isChallengesOpen: isChallengesOpen,
-                      marketDay: marketDay,
+                      isCurrentDay: marketDay == day,
                       day: day,
                     ),
                   )

--- a/lib/pages/daily_challenges/daily_challenges_page.dart
+++ b/lib/pages/daily_challenges/daily_challenges_page.dart
@@ -60,6 +60,7 @@ class _DailyChallengesPageBodyState extends State<_DailyChallengesPageBody>
 
   List<int> get days => 1.to(widget.successState.totalMarketDays);
   int get marketDay => widget.successState.marketDay;
+  bool get isChallengesOpen => widget.successState.isChallengesOpen;
 
   String dateForIndex(int tabIndex) {
     final diff = marketDay - (tabIndex + 1);
@@ -108,6 +109,7 @@ class _DailyChallengesPageBodyState extends State<_DailyChallengesPageBody>
                   BlocProvider(
                     create: (_) => SingleDayChallengesCubit(),
                     child: SingleDayChallenges(
+                      isChallengesOpen: isChallengesOpen,
                       marketDay: marketDay,
                       day: day,
                     ),

--- a/lib/pages/daily_challenges/daily_challenges_page.dart
+++ b/lib/pages/daily_challenges/daily_challenges_page.dart
@@ -27,13 +27,7 @@ class DailyChallengesPage extends StatelessWidget {
                   );
                 }
                 if (state is DailyChallengesPageSuccess) {
-                  if (state.isDailyChallengesOpen) {
-                    return _DailyChallengesPageBody(successState: state);
-                  } else {
-                    return const Center(
-                      child: Text('Daily Challenges is closed now'),
-                    );
-                  }
+                  return _DailyChallengesPageBody(successState: state);
                 }
                 return const Center(child: DalalLoadingBar());
               },

--- a/lib/pages/daily_challenges/single_day_challenges.dart
+++ b/lib/pages/daily_challenges/single_day_challenges.dart
@@ -13,13 +13,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SingleDayChallenges extends StatefulWidget {
   final bool isChallengesOpen;
-  final int marketDay;
+  final bool isCurrentDay;
   final int day;
 
   const SingleDayChallenges(
       {Key? key,
       required this.isChallengesOpen,
-      required this.marketDay,
+      required this.isCurrentDay,
       required this.day})
       : super(key: key);
 
@@ -53,7 +53,7 @@ class _SingleDayChallengesState extends State<SingleDayChallenges>
       },
       builder: (context, state) {
         if (state is SingleDayChallengesLoaded) {
-          if (widget.marketDay != widget.day) {
+          if (!widget.isCurrentDay) {
             return content(state);
           }
           // Update isOpen state only for current day challenges
@@ -114,7 +114,7 @@ class _SingleDayChallengesState extends State<SingleDayChallenges>
                 child: ListView.separated(
                   itemCount: challengeInfos.length,
                   itemBuilder: (_, i) => DailyChallengeItem(
-                    marketDay: widget.marketDay,
+                    isCurrentDay: widget.isCurrentDay,
                     challenge: challengeInfos[i].challenge,
                     userState: challengeInfos[i].userState,
                     stock: challengeInfos[i].challenge.hasStockId()

--- a/lib/streams/transformations.dart
+++ b/lib/streams/transformations.dart
@@ -1,4 +1,6 @@
 import 'package:dalal_street_client/models/dynamic_user_info.dart';
+import 'package:dalal_street_client/proto_build/datastreams/GameState.pb.dart';
+import 'package:dalal_street_client/proto_build/models/GameState.pb.dart';
 import 'package:dalal_street_client/proto_build/models/Stock.pb.dart';
 import 'package:fixnum/fixnum.dart';
 
@@ -30,4 +32,17 @@ extension StockMapStreamTransformations on Stream<Map<int, Stock>> {
 
   Stream<bool> givesDividents(int stockId) =>
       map((stocks) => stocks[stockId]!.givesDividends).distinct();
+}
+
+/// Useful extensions on gamestate stream
+extension GameStateStreamTransformations on Stream<GameStateUpdate> {
+  /// A bool stream of isDailyChallengeOpen updates
+  Stream<bool> isDailyChallengesOpenStream() async* {
+    await for (var update in this) {
+      final gameState = update.gameState;
+      if (gameState.type == GameStateUpdateType.DailyChallengeStatusUpdate) {
+        yield gameState.dailyChallengeState.isDailyChallengeOpen;
+      }
+    }
+  }
 }

--- a/lib/utils/form_validation_messages.dart
+++ b/lib/utils/form_validation_messages.dart
@@ -1,30 +1,22 @@
 import 'package:reactive_forms/reactive_forms.dart';
 
-Map<String, String> emailValidation() {
-  return {
-    ValidationMessage.required: 'The email must not be empty',
-    ValidationMessage.email: 'The email value must be a valid email',
-  };
-}
+Map<String, String> emailValidation() => {
+      ValidationMessage.required: 'Email must not be empty',
+      ValidationMessage.email: 'Enter a valid email',
+    };
 
-Map<String, String> requiredValidation(String field) {
-  return {
-    ValidationMessage.required: 'The $field must not be empty',
-  };
-}
+Map<String, String> requiredValidation(String field) => {
+      ValidationMessage.required: '$field must not be empty',
+    };
 
-Map<String, String> passwordValidation(String field) {
-  return {
-    ValidationMessage.required: 'The $field must not be empty',
-    ValidationMessage.mustMatch: 'password and confirm password must match',
-    ValidationMessage.minLength: 'The $field must have at least 6 characters'
-  };
-}
+Map<String, String> passwordValidation(String field) => {
+      ValidationMessage.required: '$field must not be empty',
+      ValidationMessage.mustMatch: 'Password and confirm password must match',
+      ValidationMessage.minLength: '$field must have at least 6 characters'
+    };
 
-Map<String, String> phoneNumberValidation() {
-  return {
-    ValidationMessage.required: 'This field is required',
-    ValidationMessage.minLength: 'Invalid phone number',
-    ValidationMessage.maxLength: 'Invalid phone number'
-  };
-}
+Map<String, String> phoneNumberValidation() => {
+      ValidationMessage.required: 'This field is required',
+      ValidationMessage.minLength: 'Invalid phone number',
+      ValidationMessage.maxLength: 'Invalid phone number'
+    };


### PR DESCRIPTION
Earlier whole page was blank if daily challenges was closed. No way to see previous day challenges.
Changed it to only block current day challenges