### PR TITLE
[fix]: remove snackbar for UserRewardCreditUpdate

### DIFF
--- a/lib/utils/stream_snackbar.dart
+++ b/lib/utils/stream_snackbar.dart
@@ -89,13 +89,6 @@ Future<void> _listenGameStateStream(BuildContext context) async {
           showSnackBar(context, 'Daily Challenge for today is closed');
         }
         break;
-
-      case GameStateUpdateType.UserRewardCreditUpdate:
-        var cash = update.gameState.userRewardCredit.cash;
-        showSnackBar(context,
-            'cash of ₹$cash is credited as your daily challenges reward',
-            type: SnackBarType.success);
-        break;
       default:
     }
   }


### PR DESCRIPTION
Two snackbars were showing when user claims a reward in daily challenges